### PR TITLE
feat(scaffold): Go monorepo with workspace and service stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@ bin/
 *.dll
 *.so
 *.dylib
+api-gateway
+order-service
+payment-service
+inventory-service
+saga-orchestrator
+notification-service
 
 # Go
 vendor/

--- a/go.work
+++ b/go.work
@@ -1,0 +1,11 @@
+go 1.26.2
+
+use (
+	./pkg
+	./services/api-gateway
+	./services/inventory-service
+	./services/notification-service
+	./services/order-service
+	./services/payment-service
+	./services/saga-orchestrator
+)

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,0 +1,3 @@
+module github.com/Nishchal45/orderflow/pkg
+
+go 1.26.2

--- a/services/api-gateway/go.mod
+++ b/services/api-gateway/go.mod
@@ -1,0 +1,3 @@
+module github.com/Nishchal45/orderflow/services/api-gateway
+
+go 1.26.2

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("OrderFlow API Gateway starting on :8080")
+}

--- a/services/inventory-service/go.mod
+++ b/services/inventory-service/go.mod
@@ -1,0 +1,3 @@
+module github.com/Nishchal45/orderflow/services/inventory-service
+
+go 1.26.2

--- a/services/inventory-service/main.go
+++ b/services/inventory-service/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("OrderFlow Inventory Service starting on :50053")
+}

--- a/services/notification-service/go.mod
+++ b/services/notification-service/go.mod
@@ -1,0 +1,3 @@
+module github.com/Nishchal45/orderflow/services/notification-service
+
+go 1.26.2

--- a/services/notification-service/main.go
+++ b/services/notification-service/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("OrderFlow Notification Service starting on :50055")
+}

--- a/services/order-service/go.mod
+++ b/services/order-service/go.mod
@@ -1,0 +1,3 @@
+module github.com/Nishchal45/orderflow/services/order-service
+
+go 1.26.2

--- a/services/order-service/main.go
+++ b/services/order-service/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("OrderFlow Order Service starting on :50051")
+}

--- a/services/payment-service/go.mod
+++ b/services/payment-service/go.mod
@@ -1,0 +1,3 @@
+module github.com/Nishchal45/orderflow/services/payment-service
+
+go 1.26.2

--- a/services/payment-service/main.go
+++ b/services/payment-service/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("OrderFlow Payment Service starting on :50052")
+}

--- a/services/saga-orchestrator/go.mod
+++ b/services/saga-orchestrator/go.mod
@@ -1,0 +1,3 @@
+module github.com/Nishchal45/orderflow/services/saga-orchestrator
+
+go 1.26.2

--- a/services/saga-orchestrator/main.go
+++ b/services/saga-orchestrator/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("OrderFlow Saga Orchestrator starting on :50054")
+}


### PR DESCRIPTION
## Summary
- Go workspace (`go.work`) linking 7 modules
- `go.mod` for each service + shared `pkg/`
- Stub `main.go` for all 6 services (compiles, prints service name)
- Updated `.gitignore` for compiled binaries

## Verification
```bash
go build ./services/api-gateway/
go build ./services/order-service/
# ... all 6 pass
```

Closes #4