### PR TITLE
feat(proto): protobuf definitions for all services

### DIFF
--- a/proto/buf.gen.yaml
+++ b/proto/buf.gen.yaml
@@ -1,0 +1,8 @@
+version: v2
+plugins:
+  - remote: buf.build/protocolbuffers/go
+    out: ../gen
+    opt: paths=source_relative
+  - remote: buf.build/grpc/go
+    out: ../gen
+    opt: paths=source_relative

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,0 +1,9 @@
+version: v2
+modules:
+  - path: .
+lint:
+  use:
+    - STANDARD
+breaking:
+  use:
+    - FILE

--- a/proto/inventory/v1/inventory.proto
+++ b/proto/inventory/v1/inventory.proto
@@ -1,0 +1,73 @@
+syntax = "proto3";
+
+package inventory.v1;
+
+option go_package = "github.com/Nishchal45/orderflow/gen/inventory/v1;inventoryv1";
+
+import "google/protobuf/timestamp.proto";
+
+service InventoryService {
+  rpc ReserveInventory(ReserveInventoryRequest) returns (InventoryResponse);
+  rpc ReleaseInventory(ReleaseInventoryRequest) returns (InventoryResponse);
+  rpc GetStock(GetStockRequest) returns (StockResponse);
+}
+
+// Enums
+
+enum ReservationStatus {
+  RESERVATION_STATUS_UNSPECIFIED = 0;
+  RESERVATION_STATUS_RESERVED = 1;
+  RESERVATION_STATUS_RELEASED = 2;
+  RESERVATION_STATUS_CONFIRMED = 3;
+}
+
+// Messages
+
+message Product {
+  string id = 1;
+  string name = 2;
+  int32 stock = 3;
+  int32 reserved = 4;
+  int32 available = 5;
+  google.protobuf.Timestamp updated_at = 6;
+}
+
+message Reservation {
+  string id = 1;
+  string order_id = 2;
+  string product_id = 3;
+  int32 quantity = 4;
+  ReservationStatus status = 5;
+  google.protobuf.Timestamp created_at = 6;
+}
+
+// Request/Response
+
+message ReserveInventoryRequest {
+  string order_id = 1;
+  repeated ReserveItem items = 2;
+  bool simulate_failure = 3;
+}
+
+message ReserveItem {
+  string product_id = 1;
+  int32 quantity = 2;
+}
+
+message InventoryResponse {
+  bool success = 1;
+  string message = 2;
+  repeated Reservation reservations = 3;
+}
+
+message ReleaseInventoryRequest {
+  string order_id = 1;
+}
+
+message GetStockRequest {
+  string product_id = 1;
+}
+
+message StockResponse {
+  Product product = 1;
+}

--- a/proto/order/v1/order.proto
+++ b/proto/order/v1/order.proto
@@ -1,0 +1,91 @@
+syntax = "proto3";
+
+package order.v1;
+
+option go_package = "github.com/Nishchal45/orderflow/gen/order/v1;orderv1";
+
+import "google/protobuf/timestamp.proto";
+
+service OrderService {
+  rpc CreateOrder(CreateOrderRequest) returns (CreateOrderResponse);
+  rpc GetOrder(GetOrderRequest) returns (Order);
+  rpc ListOrders(ListOrdersRequest) returns (ListOrdersResponse);
+  rpc UpdateOrderStatus(UpdateOrderStatusRequest) returns (Order);
+}
+
+// Enums
+
+enum OrderStatus {
+  ORDER_STATUS_UNSPECIFIED = 0;
+  ORDER_STATUS_CREATED = 1;
+  ORDER_STATUS_INVENTORY_RESERVING = 2;
+  ORDER_STATUS_PAYMENT_PENDING = 3;
+  ORDER_STATUS_CONFIRMED = 4;
+  ORDER_STATUS_SHIPPED = 5;
+  ORDER_STATUS_ROLLING_BACK = 6;
+  ORDER_STATUS_CANCELLED = 7;
+  ORDER_STATUS_REJECTED = 8;
+}
+
+// Messages
+
+message OrderItem {
+  string id = 1;
+  string order_id = 2;
+  string product_id = 3;
+  int32 quantity = 4;
+  double unit_price = 5;
+}
+
+message Order {
+  string id = 1;
+  string customer_id = 2;
+  OrderStatus status = 3;
+  double total_amount = 4;
+  string currency = 5;
+  repeated OrderItem items = 6;
+  google.protobuf.Timestamp created_at = 7;
+  google.protobuf.Timestamp updated_at = 8;
+}
+
+// Request/Response
+
+message CreateOrderRequest {
+  string customer_id = 1;
+  repeated CreateOrderItem items = 2;
+  bool simulate_payment_failure = 3;
+  bool simulate_inventory_failure = 4;
+}
+
+message CreateOrderItem {
+  string product_id = 1;
+  int32 quantity = 2;
+  double unit_price = 3;
+}
+
+message CreateOrderResponse {
+  Order order = 1;
+}
+
+message GetOrderRequest {
+  string id = 1;
+}
+
+message ListOrdersRequest {
+  int32 page = 1;
+  int32 limit = 2;
+  string customer_id = 3;
+  OrderStatus status = 4;
+}
+
+message ListOrdersResponse {
+  repeated Order orders = 1;
+  int32 total = 2;
+  int32 page = 3;
+  int32 limit = 4;
+}
+
+message UpdateOrderStatusRequest {
+  string id = 1;
+  OrderStatus status = 2;
+}

--- a/proto/payment/v1/payment.proto
+++ b/proto/payment/v1/payment.proto
@@ -1,0 +1,58 @@
+syntax = "proto3";
+
+package payment.v1;
+
+option go_package = "github.com/Nishchal45/orderflow/gen/payment/v1;paymentv1";
+
+import "google/protobuf/timestamp.proto";
+
+service PaymentService {
+  rpc ProcessPayment(ProcessPaymentRequest) returns (PaymentResponse);
+  rpc RefundPayment(RefundPaymentRequest) returns (PaymentResponse);
+  rpc GetPayment(GetPaymentRequest) returns (Payment);
+}
+
+// Enums
+
+enum PaymentStatus {
+  PAYMENT_STATUS_UNSPECIFIED = 0;
+  PAYMENT_STATUS_PENDING = 1;
+  PAYMENT_STATUS_COMPLETED = 2;
+  PAYMENT_STATUS_FAILED = 3;
+  PAYMENT_STATUS_REFUNDED = 4;
+}
+
+// Messages
+
+message Payment {
+  string id = 1;
+  string order_id = 2;
+  double amount = 3;
+  string currency = 4;
+  PaymentStatus status = 5;
+  string failure_reason = 6;
+  google.protobuf.Timestamp created_at = 7;
+  google.protobuf.Timestamp updated_at = 8;
+}
+
+// Request/Response
+
+message ProcessPaymentRequest {
+  string order_id = 1;
+  double amount = 2;
+  string currency = 3;
+  bool simulate_failure = 4;
+}
+
+message PaymentResponse {
+  Payment payment = 1;
+}
+
+message RefundPaymentRequest {
+  string payment_id = 1;
+  string order_id = 2;
+}
+
+message GetPaymentRequest {
+  string id = 1;
+}

--- a/proto/saga/v1/saga.proto
+++ b/proto/saga/v1/saga.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+
+package saga.v1;
+
+option go_package = "github.com/Nishchal45/orderflow/gen/saga/v1;sagav1";
+
+import "google/protobuf/timestamp.proto";
+
+// Enums
+
+enum SagaStatus {
+  SAGA_STATUS_UNSPECIFIED = 0;
+  SAGA_STATUS_STARTED = 1;
+  SAGA_STATUS_COMPLETED = 2;
+  SAGA_STATUS_FAILED = 3;
+  SAGA_STATUS_COMPENSATING = 4;
+  SAGA_STATUS_COMPENSATED = 5;
+}
+
+enum StepStatus {
+  STEP_STATUS_UNSPECIFIED = 0;
+  STEP_STATUS_PENDING = 1;
+  STEP_STATUS_EXECUTING = 2;
+  STEP_STATUS_COMPLETED = 3;
+  STEP_STATUS_FAILED = 4;
+  STEP_STATUS_COMPENSATING = 5;
+  STEP_STATUS_COMPENSATED = 6;
+}
+
+// Messages
+
+message Saga {
+  string id = 1;
+  string order_id = 2;
+  SagaStatus status = 3;
+  string current_step = 4;
+  repeated SagaStep steps = 5;
+  string failure_reason = 6;
+  google.protobuf.Timestamp started_at = 7;
+  google.protobuf.Timestamp completed_at = 8;
+}
+
+message SagaStep {
+  string id = 1;
+  string saga_id = 2;
+  string step_name = 3;
+  StepStatus status = 4;
+  string error = 5;
+  google.protobuf.Timestamp started_at = 6;
+  google.protobuf.Timestamp completed_at = 7;
+}
+
+// Event envelope used across all Kafka messages
+
+message Event {
+  string event_id = 1;
+  string event_type = 2;
+  string aggregate_id = 3;
+  google.protobuf.Timestamp timestamp = 4;
+  int32 version = 5;
+  bytes payload = 6;
+  EventMetadata metadata = 7;
+}
+
+message EventMetadata {
+  string trace_id = 1;
+  string source = 2;
+  string correlation_id = 3;
+}


### PR DESCRIPTION
## Summary
- Protocol Buffer definitions for all 4 gRPC services
- Buf tooling config for linting and Go code generation
- Event envelope for Kafka message serialization

## Proto Files
| File | Service | RPCs |
|------|---------|------|
| `order/v1/order.proto` | OrderService | CreateOrder, GetOrder, ListOrders, UpdateOrderStatus |
| `payment/v1/payment.proto` | PaymentService | ProcessPayment, RefundPayment, GetPayment |
| `inventory/v1/inventory.proto` | InventoryService | ReserveInventory, ReleaseInventory, GetStock |
| `saga/v1/saga.proto` | — | Saga/Step types, Event envelope |

Closes #6