### PR TITLE
feat(gateway): API Gateway with reverse proxy and middleware

### DIFF
--- a/services/api-gateway/go.mod
+++ b/services/api-gateway/go.mod
@@ -1,3 +1,17 @@
 module github.com/Nishchal45/orderflow/services/api-gateway
 
 go 1.26.2
+
+replace github.com/Nishchal45/orderflow/pkg => ../../pkg
+
+require (
+	github.com/Nishchal45/orderflow/pkg v0.0.0-00010101000000-000000000000
+	github.com/google/uuid v1.6.0
+	github.com/rs/zerolog v1.35.0
+)
+
+require (
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	golang.org/x/sys v0.42.0 // indirect
+)

--- a/services/api-gateway/go.sum
+++ b/services/api-gateway/go.sum
@@ -1,0 +1,11 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/rs/zerolog v1.35.0 h1:VD0ykx7HMiMJytqINBsKcbLS+BJ4WYjz+05us+LRTdI=
+github.com/rs/zerolog v1.35.0/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+jcw=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
+golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/services/api-gateway/internal/middleware/middleware.go
+++ b/services/api-gateway/internal/middleware/middleware.go
@@ -1,0 +1,79 @@
+package middleware
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+// RequestID adds a unique X-Request-ID header to every request.
+func RequestID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestID := r.Header.Get("X-Request-ID")
+		if requestID == "" {
+			requestID = uuid.New().String()
+		}
+		w.Header().Set("X-Request-ID", requestID)
+		r.Header.Set("X-Request-ID", requestID)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// Logger logs every request with method, path, status, and duration.
+func Logger(log zerolog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			wrapped := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+			next.ServeHTTP(wrapped, r)
+			log.Info().
+				Str("method", r.Method).
+				Str("path", r.URL.Path).
+				Int("status", wrapped.statusCode).
+				Dur("duration", time.Since(start)).
+				Str("request_id", w.Header().Get("X-Request-ID")).
+				Msg("request")
+		})
+	}
+}
+
+// CORS allows the dashboard (localhost:3000) to make requests.
+func CORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Request-ID")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// Recovery catches panics and returns a 500 instead of crashing.
+func Recovery(log zerolog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if err := recover(); err != nil {
+					log.Error().Interface("panic", err).Str("path", r.URL.Path).Msg("recovered from panic")
+					http.Error(w, `{"error":{"code":500,"message":"internal server error"}}`, http.StatusInternalServerError)
+				}
+			}()
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}

--- a/services/api-gateway/internal/proxy/proxy.go
+++ b/services/api-gateway/internal/proxy/proxy.go
@@ -1,0 +1,38 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/rs/zerolog"
+)
+
+// ServiceProxy forwards requests to a backend service.
+type ServiceProxy struct {
+	proxy  *httputil.ReverseProxy
+	logger zerolog.Logger
+}
+
+// NewServiceProxy creates a reverse proxy to the given backend URL.
+func NewServiceProxy(target string, logger zerolog.Logger) (*ServiceProxy, error) {
+	u, err := url.Parse(target)
+	if err != nil {
+		return nil, err
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(u)
+
+	// Custom error handler
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		logger.Error().Err(err).Str("target", target).Str("path", r.URL.Path).Msg("proxy error")
+		http.Error(w, `{"error":{"code":502,"message":"service unavailable"}}`, http.StatusBadGateway)
+	}
+
+	return &ServiceProxy{proxy: proxy, logger: logger}, nil
+}
+
+// ServeHTTP forwards the request to the backend service.
+func (sp *ServiceProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	sp.proxy.ServeHTTP(w, r)
+}

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -1,7 +1,70 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/Nishchal45/orderflow/pkg/logger"
+	"github.com/Nishchal45/orderflow/services/api-gateway/internal/middleware"
+	"github.com/Nishchal45/orderflow/services/api-gateway/internal/proxy"
+)
 
 func main() {
-	fmt.Println("OrderFlow API Gateway starting on :8080")
+	log := logger.New("api-gateway")
+	log.Info().Msg("starting API gateway")
+
+	// Backend service URLs (configurable via env vars)
+	orderServiceURL := getEnv("ORDER_SERVICE_URL", "http://localhost:8081")
+
+	// Create reverse proxies to backend services
+	orderProxy, err := proxy.NewServiceProxy(orderServiceURL, log)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to create order service proxy")
+	}
+	log.Info().Str("url", orderServiceURL).Msg("order service proxy ready")
+
+	// Set up routes
+	mux := http.NewServeMux()
+
+	// Order routes → forward to Order Service
+	mux.Handle("/api/v1/orders", orderProxy)
+	mux.Handle("/api/v1/orders/", orderProxy)
+
+	// Health check (gateway's own)
+	mux.HandleFunc("/api/v1/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"status":"ok","service":"api-gateway"}`)
+	})
+
+	// Apply middleware (order matters: outermost runs first)
+	var handler http.Handler = mux
+	handler = middleware.CORS(handler)
+	handler = middleware.RequestID(handler)
+	handler = middleware.Recovery(log)(handler)
+	handler = middleware.Logger(log)(handler)
+
+	// Start server
+	port := getEnv("HTTP_PORT", "8080")
+	go func() {
+		log.Info().Str("port", port).Msg("api gateway listening")
+		if err := http.ListenAndServe(":"+port, handler); err != nil {
+			log.Fatal().Err(err).Msg("gateway failed")
+		}
+	}()
+
+	// Wait for shutdown
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+	log.Info().Msg("shutting down api gateway")
+}
+
+func getEnv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
 }


### PR DESCRIPTION
## Summary
API Gateway that acts as the single entry point for all client requests.

- Reverse proxy to Order Service (and later Payment, Inventory)
- Middleware stack: Request ID, Logger, CORS, Recovery
- Tested: `curl localhost:8080/api/v1/orders` → proxied to Order Service → 201 Created

## Flow
```
Client :8080 → API Gateway → Order Service :8081 → PostgreSQL → Kafka
```

Closes #13 #14